### PR TITLE
Add instance name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class varnish (
   $secret          = undef,
   $secret_file     = $varnish::params::secret_file,
   $vcl_conf        = $varnish::params::vcl_conf,
+  $instance_name   = $varnish::params::instance_name,
   $listen          = $varnish::params::listen,
   $listen_port     = $varnish::params::listen_port,
   $extra_listen    = "",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,6 +81,7 @@ class varnish::params {
 
   # Standard Varnish sysconfig settings
   $vcl_conf       = '/etc/varnish/default.vcl'
+  $instance_name  = 'varnish'
   $listen         = '0.0.0.0'
   $listen_port    = 6081
   $admin_listen   = '127.0.0.1'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,7 +81,7 @@ class varnish::params {
 
   # Standard Varnish sysconfig settings
   $vcl_conf       = '/etc/varnish/default.vcl'
-  $instance_name  = 'varnish'
+  $instance_name  = <%= @hostname %>
   $listen         = '0.0.0.0'
   $listen_port    = 6081
   $admin_listen   = '127.0.0.1'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,7 +81,7 @@ class varnish::params {
 
   # Standard Varnish sysconfig settings
   $vcl_conf       = '/etc/varnish/default.vcl'
-  $instance_name  = <%= @fqdn %>
+  $instance_name  = ${::fqdn}
   $listen         = '0.0.0.0'
   $listen_port    = 6081
   $admin_listen   = '127.0.0.1'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,7 +81,7 @@ class varnish::params {
 
   # Standard Varnish sysconfig settings
   $vcl_conf       = '/etc/varnish/default.vcl'
-  $instance_name  = <%= @hostname %>
+  $instance_name  = <%= @fqdn %>
   $listen         = '0.0.0.0'
   $listen_port    = 6081
   $admin_listen   = '127.0.0.1'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,7 +81,7 @@ class varnish::params {
 
   # Standard Varnish sysconfig settings
   $vcl_conf       = '/etc/varnish/default.vcl'
-  $instance_name  = '::fqdn'
+  $instance_name  = downcase($::fqdn)
   $listen         = '0.0.0.0'
   $listen_port    = 6081
   $admin_listen   = '127.0.0.1'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,7 +81,7 @@ class varnish::params {
 
   # Standard Varnish sysconfig settings
   $vcl_conf       = '/etc/varnish/default.vcl'
-  $instance_name  = ${::fqdn}
+  $instance_name  = '::fqdn'
   $listen         = '0.0.0.0'
   $listen_port    = 6081
   $admin_listen   = '127.0.0.1'

--- a/templates/el7/varnish-4-systemd.erb
+++ b/templates/el7/varnish-4-systemd.erb
@@ -31,6 +31,7 @@ PrivateTmp=true
 ExecStart=/usr/sbin/varnishd \
     -P /var/run/varnish.pid \
     -f $VARNISH_VCL_CONF \
+    -n ${VARNISH_INSTANCE_NAME} \
     -a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \<% if scope['varnish::extra_listen'] != "" %>
     ${VARNISH_EXTRA_LISTEN} \<% end %>
     -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \

--- a/templates/el7/varnish-4.sysconfig.erb
+++ b/templates/el7/varnish-4.sysconfig.erb
@@ -1,6 +1,7 @@
 ### This file created by Puppet, modification is probably futile
 RELOAD_VCL=1
 VARNISH_VCL_CONF=<%= scope['::varnish::vcl_conf'] %>
+VARNISH_INSTANCE_NAME=<%= scope['::varnish::instance_name'] %>
 VARNISH_LISTEN_ADDRESS=<%= scope['::varnish::listen'] %>
 VARNISH_LISTEN_PORT=<%= scope['::varnish::listen_port'] %>
 # VARNISH_EXTRA_LISTEN is a list of additional ips/ports to listen on, including the -a flag. e.g. VARNISH_EXTRA_LISTEN="-a 127.0.0.1:80"


### PR DESCRIPTION
Explicitly sets instance name to `$::fqdn` to avoid the condition where the FQDN is changed after Varnish starts but before varnishncsa starts.